### PR TITLE
Limit sitemap training links

### DIFF
--- a/packages/worker/src/api/http/controllers/train.controller.ts
+++ b/packages/worker/src/api/http/controllers/train.controller.ts
@@ -2,6 +2,7 @@ import type { Context } from 'hono'
 import * as TrainService from '~/core/services/train.service'
 import ResponseHandler from '~/lib/utils/response-handler'
 import { TrainingTaskRepository } from '~/core/repositories/train.repository'
+import DataLoader from '~/lib/utils/ai/data-loader'
 
 export async function load(c: Context) {
   const body = await c.req.json()
@@ -21,6 +22,12 @@ export async function loadFile(c: Context) {
   return ResponseHandler.success(c, {
     message: 'Noice',
   })
+}
+
+export async function loadSitemap(c: Context) {
+  const data = (await DataLoader.sitemap('https://www.lupus.org/sitemap.xml')).map(link => link.loc)
+
+  return ResponseHandler.success(c, data)
 }
 
 export async function list(c: Context) {

--- a/packages/worker/src/api/http/routes/train.route.ts
+++ b/packages/worker/src/api/http/routes/train.route.ts
@@ -6,4 +6,5 @@ export const route = new Hono<Environment>()
 
 route.post('/load', TrainController.load)
 route.post('/load-file', TrainController.loadFile)
+route.get('/sitemap', TrainController.loadSitemap)
 route.get('/list', TrainController.list)

--- a/packages/worker/src/core/services/train.service.ts
+++ b/packages/worker/src/core/services/train.service.ts
@@ -1,6 +1,6 @@
 import type { Document } from 'langchain/document'
 import { KnowledgeRepository } from '../repositories/knowledge.repository'
-import type { KnowledgeMeta } from '~/lib/validations/train.validation'
+import type { KnowledgeMeta, SitemapFilters } from '~/lib/validations/train.validation'
 import { LoadKnowledgeSchema, PdfLoadSchema } from '~/lib/validations/train.validation'
 import type { Bindings } from '~/common/interfaces/common.interface'
 import { addDocumentsToStore } from '~/lib/utils/ai/embeddings'
@@ -98,11 +98,11 @@ async function handleSitemap(
   env: Bindings,
   taskId: number,
   sitemapUrl: string,
+  filters: SitemapFilters,
 ) {
   const taskRepo = new TrainingTaskRepository(env)
-  console.log(`Handling sitemap ${sitemapUrl}`, { taskId, sitemapUrl })
 
-  const links = await DataLoader.sitemap(sitemapUrl)
+  const links = await DataLoader.sitemap(sitemapUrl, filters.start, filters.maxUrls)
   const results = await Promise.allSettled(
     links.map(link =>
       handleKnowledge(env, taskId, 'url', link.loc).catch((error) => {

--- a/packages/worker/src/lib/utils/ai/data-loader.ts
+++ b/packages/worker/src/lib/utils/ai/data-loader.ts
@@ -96,10 +96,11 @@ class DataLoader implements Loader {
     return await splitter.splitDocuments(rawDocs)
   }
 
-  async sitemap(url: string) {
+  async sitemap(url: string, start: number = 0, maxUrls: number = 500) {
     const loader = new SitemapLoader(url)
+    const urls = await loader.parseSitemap()
 
-    return await loader.parseSitemap()
+    return urls.slice(start, start + maxUrls)
   }
 }
 

--- a/packages/worker/src/lib/validations/train.validation.ts
+++ b/packages/worker/src/lib/validations/train.validation.ts
@@ -11,9 +11,17 @@ const PdfTypeSchema = z.object({
   source: validPDF,
 })
 
+const SitemapFiltersSchema = z.object({
+  start: z.number().min(0),
+  maxUrls: z.number().max(999),
+})
+
+export type SitemapFilters = z.infer<typeof SitemapFiltersSchema>
+
 const SitemapTypeSchema = z.object({
   type: z.literal('sitemap'),
   source: z.string().url(),
+  filters: SitemapFiltersSchema.optional(),
 })
 
 export const KnowledgeTypeSchema = z.discriminatedUnion('type', [


### PR DESCRIPTION
Due to the workers subrequest limits, if the sitemap contains more than 1000 links, it should be split into multiple training requests